### PR TITLE
add core-dev to get needed packages for running tests

### DIFF
--- a/travis_setup_drupal.sh
+++ b/travis_setup_drupal.sh
@@ -28,6 +28,7 @@ else
   php -dmemory_limit=-1 $COMPOSER_PATH install
 fi
 
+composer require "drupal/core-dev:^8.9"
 composer require drush/drush
 echo "Setup Drush"
 sudo ln -s /opt/drupal/vendor/bin/drush /usr/bin/drush


### PR DESCRIPTION
Add drupal/core-dev package to the travis builds so it gets all the core-dev dependencies for running tests
note that it has to be installed BEFORE drush per https://www.drupal.org/docs/develop/using-composer/starting-a-site-using-drupal-composer-project-templates#s-adding-drupalcore-dev