### PR TITLE
Allow newer Drush for newer Drupal

### DIFF
--- a/travis_setup_drupal.sh
+++ b/travis_setup_drupal.sh
@@ -35,6 +35,9 @@ fi
 composer require "drupal/core-dev:$DRUPAL_VERSION"
 DRUPAL_MAJOR=$(echo "$DRUPAL_VERSION" | cut -d. -f1)
 if [ $DRUPAL_MAJOR -ge 9 ]; then
+  # XXX: 9.4.x-dev installs phpunit 8... but then we expect to have to install 
+  # the phpspec/prophecy-phpunit:^2 thing, which only works with phpunit 9.
+  composer require -W phpunit/phpunit:^9
   composer require phpspec/prophecy-phpunit:^2 drush/drush
 elif [ $DRUPAL_MAJOR -eq 8 ]; then
   composer require drush/drush:^10

--- a/travis_setup_drupal.sh
+++ b/travis_setup_drupal.sh
@@ -35,9 +35,16 @@ fi
 composer require "drupal/core-dev:$DRUPAL_VERSION"
 DRUPAL_MAJOR=$(echo "$DRUPAL_VERSION" | cut -d. -f1)
 if [ $DRUPAL_MAJOR -ge 9 ]; then
-   composer require phpspec/prophecy-phpunit:^2
+  composer require phpspec/prophecy-phpunit:^2 drush/drush
+elif [ $DRUPAL_MAJOR -eq 8 ]; then
+  composer require drush/drush:^10
+elif [ $DRUPAL_MAJOR -eq 7 ]; then
+  composer require drush/drush:^8
+else
+  echo "Unmapped major version of Drupal: $DRUPAL_MAJOR"
+  exit 1
 fi
-composer require drush/drush=~10
+
 echo "Setup Drush"
 sudo ln -s /opt/drupal/vendor/bin/drush /usr/bin/drush
 phpenv rehash


### PR DESCRIPTION
https://github.com/Islandora/islandora_ci/pull/8 fixed solidly to drush 10 to maintain compatibility with Drupal 8 and 9; however, we now have Drupal 10 in our testing matrix, for which drush 11 is required... so let it be used accordingly.

Should hopefully address some tests which blow up due to Drush 10 not supporting Drupal 10, such as:
* https://github.com/Islandora/islandora/runs/6678217486?check_suite_focus=true#step:9:433
    
    ```
       Problem 1
        - drush/drush[10.0.0-alpha1, ..., 10.3.5] require composer/semver ^1.4 -> found composer/semver[1.4.0, ..., 1.x-dev] but the package is fixed to 3.3.2 (lock file version) by a partial update and that version does not match. Make sure you list it as an argument for the update command.
    Error: Your requirements could not be resolved to an installable set of packages.
    ```
* https://github.com/Islandora/islandora/runs/6728671150?check_suite_focus=true#step:9:430

    ```
       Problem 1
        - drush/drush[10.0.0-alpha1, ..., 10.3.5] require composer/semver ^1.4 -> found composer/semver[1.4.0, ..., 1.x-dev] but the package is fixed to 3.3.2 (lock file version) by a partial update and that version does not match. Make sure you list it as an argument for the update command.
    Error: Your requirements could not be resolved to an installable set of packages.
    ```