### PR TITLE
Invoke phpcpd as per its command-line help.

### DIFF
--- a/travis_scripts.sh
+++ b/travis_scripts.sh
@@ -16,7 +16,7 @@ checkReturn $?
 phpcs --standard=Drupal --ignore=*.md,*-min.css --extensions=php,module,inc,install,test,profile,theme,css,info $GITHUB_WORKSPACE/build_dir
 checkReturn $?
 
-phpcpd --suffix *.module,*.inc,*.test,*.php $GITHUB_WORKSPACE/build_dir
+phpcpd --suffix *.module --suffix *.inc --suffix *.install --suffix *.test --suffix *.php $GITHUB_WORKSPACE/build_dir
 checkReturn $?
 
 exit $OUTPUT


### PR DESCRIPTION
# What does this Pull Request do?

Fix breaking builds first noticed on this PR: https://github.com/Islandora/islandora_defaults/pull/75

* **Related GitHub Issue**: (link)

[#14 \[BUG\]phpcpd is being invoked incorrectly](https://github.com/Islandora/islandora_ci/issues/14)

# What's new?

Changes how phpcpd is invoked in travis_scripts.sh

* Does this change add any new dependencies?  No
* Does this change require any other modifications to be made to the repository
 (i.e. Regeneration activity, etc.)?  No
* Could this change impact execution of existing code? No

# How should this be tested?


Kick off a build of the above islandora_defaults PR.

# Documentation Status

* Does this change existing behaviour that's currently documented? No
* Does this change require new pages or sections of documentation? No
* Who does this need to be documented for? N/A
* Associated documentation pull request(s): ___  or documentation issue ___

# Interested parties
Tag (@ mention) interested parties or, if unsure, @Islandora/committers
