### PR TITLE
Remove asterisks from phpcpd command line.

### DIFF
--- a/travis_scripts.sh
+++ b/travis_scripts.sh
@@ -16,7 +16,7 @@ checkReturn $?
 phpcs --standard=Drupal --ignore=*.md,*-min.css --extensions=php,module,inc,install,test,profile,theme,css,info $GITHUB_WORKSPACE/build_dir
 checkReturn $?
 
-phpcpd --suffix *.module --suffix *.inc --suffix *.install --suffix *.test --suffix *.php $GITHUB_WORKSPACE/build_dir
+phpcpd --suffix .module --suffix .inc --suffix .install --suffix .test --suffix .php $GITHUB_WORKSPACE/build_dir
 checkReturn $?
 
 exit $OUTPUT


### PR DESCRIPTION
# What does this Pull Request do?

Somehow even though it ran correctly in my local Linux box with the "--suffix *.php" etc options, it was still failing in CI.

Removed the asterisks and tested on the branch 'GitHub-actions-test-breakout-mirador' of islandora_ci.

* **Related GitHub Issue**: (link)

[\[BUG\]phpcpd is being invoked incorrectly](https://github.com/Islandora/islandora_ci/issues/14)

# What's new?

The phpcpd invocation now has suffixes with no asterisk before the file extension.

* Does this change add any new dependencies?  No
* Does this change require any other modifications to be made to the repository
 (i.e. Regeneration activity, etc.)?  No
* Could this change impact execution of existing code? No

# How should this be tested?

Cause the CI to run on this PR:

https://github.com/Islandora/islandora_defaults/pull/75

# Documentation Status

* Does this change existing behaviour that's currently documented? No
* Does this change require new pages or sections of documentation? No
* Who does this need to be documented for? CI robot
* Associated documentation pull request(s): ___  or documentation issue ___

# Additional Notes:
Any additional information that you think would be helpful when reviewing this

![dunse hat](
![](http://www.emofaces.com/png/200/emoticons/dunce.png)
)
Tested on the CI infrastructure and it works:

![image](https://user-images.githubusercontent.com/82412/190197109-8e17378c-7026-48da-ba79-892977069ae2.png)



# Interested parties
Tag (@ mention) interested parties or, if unsure, @Islandora/committers
