### PR TITLE
Temporarily exclude PDF if D10

### DIFF
--- a/travis_setup_drupal.sh
+++ b/travis_setup_drupal.sh
@@ -61,21 +61,23 @@ echo "Enable simpletest module"
 drush --uri=127.0.0.1:8282 en -y simpletest
 
 # Install pdfjs
-cd /opt/drupal
-if [ -z "$COMPOSER_PATH" ]; then
-  composer require "drupal/pdf:1.x-dev"
-else
-  php -dmemory_limit=-1 $COMPOSER_PATH require "drupal/pdf:1.x-dev"
+# Skip if Drupal 10, since drupal/pdf is not yet compatible.
+if [ $DRUPAL_MAJOR -le 9 ]; then
+  cd /opt/drupal
+  if [ -z "$COMPOSER_PATH" ]; then
+    composer require "drupal/pdf:1.x-dev"
+  else
+    php -dmemory_limit=-1 $COMPOSER_PATH require "drupal/pdf:1.x-dev"
+  fi
+  cd web
+  mkdir libraries
+  cd libraries
+  wget "https://github.com/mozilla/pdf.js/releases/download/v2.0.943/pdfjs-2.0.943-dist.zip"
+  mkdir pdf.js
+  unzip pdfjs-2.0.943-dist.zip -d pdf.js
+  rm pdfjs-2.0.943-dist.zip
+
+  cd ..
+  drush -y en pdf
 fi
-
-cd web
-mkdir libraries
-cd libraries
-wget "https://github.com/mozilla/pdf.js/releases/download/v2.0.943/pdfjs-2.0.943-dist.zip"
-mkdir pdf.js
-unzip pdfjs-2.0.943-dist.zip -d pdf.js
-rm pdfjs-2.0.943-dist.zip
-
-cd ..
-drush -y en pdf
 


### PR DESCRIPTION
# What does this Pull Request do?

Drupal 10 tests for all our modules fail because Islandora CI installs PDF, which doesn't have a D10 version yet. 

It would be really useful to be able to test the majority of our modules, which do not require pdf, on Drupal 10. Therefore I'm proposing this as a temporary fix.

* **Related GitHub Issue**: (link)

* **Other Relevant Links**: 
Example PR: https://github.com/Islandora/jsonld/pull/69

# What's new?
Skip PDF installation if Drupal 10.


# How should this be tested?

I'm not sure, but once committed, D10 pull requests should be tested with a suite that doesn't fail when trying to install the pdf module.


# Documentation Status

* Does this change existing behaviour that's currently documented? NO
* Does this change require new pages or sections of documentation? NO
* Who does this need to be documented for? NO
* Associated documentation pull request(s): ___  or documentation issue ___ N/A

# Additional Notes:
Any additional information that you think would be helpful when reviewing this
 PR.

# Interested parties
 @adam-vessey  @whikloj 
